### PR TITLE
[mipsevm] Handle F_GETFD

### DIFF
--- a/crates/mipsevm/src/mips/mips_vm.rs
+++ b/crates/mipsevm/src/mips/mips_vm.rs
@@ -350,7 +350,17 @@ where
                     }
                 },
                 Syscall::Fcntl => {
-                    if a1 == 3 {
+                    if a1 == 1 { // F_GETFD: get file descriptor flags
+                        match (a0 as u8).try_into() {
+                            Ok(Fd::StdIn | Fd::Stdout | Fd::StdErr | Fd::PreimageRead | Fd::HintRead | Fd::PreimageWrite | Fd::HintWrite) => {
+                                v0 = 0 // No flags set
+                            }
+                            _ => {
+                                v0 = 0xFFFFFFFF;
+                                v1 = MIPS_EBADF
+                            }
+                        }
+                    } else if a1 == 3 {
                         match (a0 as u8).try_into() {
                             Ok(Fd::StdIn | Fd::PreimageRead | Fd::HintRead) => {
                                 v0 = 0; // O_RDONLY


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/blob/e7085e537b4a0c95d41b048cfcfdd7ad24808337/cannon/mipsevm/exec/mips_syscalls.go#L257

Without it, preimage is not used and the execution trace for the same elf will be different from the Go-made cannon.